### PR TITLE
fix: bg-color for chat assistant in dark mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -16,3 +16,7 @@ h1, h2, h3, h4, h5, h6 {
 .prose :where(img):not(:where([class~=not-prose],[class~=not-prose] *)) {
   margin-top: 0;
 }
+
+.dark .chat-assistant-floating-input::before {
+  background: rgb(var(--gray-900));
+}


### PR DESCRIPTION
<table>
<thead>
<tr>
<th width="50%">Before</th>
<th width="50%">After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="1438" height="298" alt="CleanShot 2026-05-05 at 11  08 40@2x" src="https://github.com/user-attachments/assets/50a77515-12ec-4fda-8e29-a3a435f4df6b" />

</td>
<td>
<img width="1438" height="298" alt="CleanShot 2026-05-05 at 11  08 32@2x" src="https://github.com/user-attachments/assets/9ed2796d-a68d-4e4c-a104-07db441f0770" />

</td>
</tr>
</tbody>
</table>